### PR TITLE
workflow: Upload output zips

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,3 +27,8 @@ jobs:
         script: |
           cargo install --git https://github.com/chevdor/tera-cli --tag v0.3.0 --root .
           bash build.sh
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: output
+        path: output/*.zip

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -27,3 +27,8 @@ jobs:
         script: |
           cargo install --git https://github.com/chevdor/tera-cli --tag v0.3.0 --root .
           bash build.sh
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: output
+        path: output/*.zip


### PR DESCRIPTION
This winds up being un-ergonomic. The output.zip file contains a zip file for each site. 